### PR TITLE
Fix bug in evaluating min tweets parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ used in a round-robin mode.
 ## Using the component
 
 NodeJS Twitter Crawler is implemented using promises. You will need to use promises
-pattern no add callbacks to crawler method invocations.
+pattern to add callbacks to crawler method invocations.
 
 ```JavaScript
 var crawler = new TwitterCrawler(credentials);

--- a/lib/twitter-crawler.js
+++ b/lib/twitter-crawler.js
@@ -217,7 +217,7 @@ module.exports = class {
             const message = (
               `Not enough tweets for user @${user.screen_name}: ` +
               `expected at least ${options.min_tweets} ` +
-              `but user has ${tweetsCount} tweets.`
+              `but user has ${tweetsCount} tweets (incl RT).`
             );
             log.error(message);
             reject(new Error(message));
@@ -248,7 +248,20 @@ module.exports = class {
                 `All tweets obtained for user @${user.screen_name}.`,
                 `Total retrieved ${outputTweets.length}.`
               );
-              resolve(outputTweets);
+
+              //Check if we have enough tweets
+              if (!this.hasAtLeast(options.min_tweets, outputTweets.length)) {
+                const message = (
+                  `Not enough tweets for user @${user.screen_name}: ` +
+                  `expected at least ${options.min_tweets} ` +
+                  `but user has ${tweetsCount} tweets.`
+                );
+                log.error(message);
+                reject(new Error(message));
+              }
+              else {
+                resolve(outputTweets);
+              }
             }
           }
         } else {
@@ -257,7 +270,20 @@ module.exports = class {
             `All tweets obtained for user ${params.screen_name ? '@' + params.screen_name : params.user_id}.`,
             `Total retrieved ${outputTweets.length}.`
           );
-          resolve(outputTweets)
+
+          //Check if we have enough tweets
+          if (!this.hasAtLeast(options.min_tweets, outputTweets.length)) {
+            const message = (
+              `Not enough tweets for user @${user.screen_name}: ` +
+              `expected at least ${options.min_tweets} ` +
+              `but user has ${tweetsCount} tweets.`
+            );
+            log.error(message);
+            reject(new Error(message));
+          }
+          else {
+            resolve(outputTweets)
+          }
         }
 
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-crawler",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NodeJS Crawler for Twitter",
   "engines": { "node" : ">=6.0.0" },
   "keywords": [


### PR DESCRIPTION
This crawler gets all the author's tweets excluding RT, however the check for minimum number of tweets only tested whether the total number of tweets (which includes RT) was greater than the limit set, not whether the actual number of tweets crawled (which doesn't have RT) was greater than the min limit.

Added these checks.